### PR TITLE
Fix single server timer accepting number as seconds and not minutes

### DIFF
--- a/maintenance-core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/maintenance-core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -110,7 +110,7 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
     }
 
     public MaintenanceRunnableBase startSingleMaintenanceRunnable(final Server server, final int minutes, final boolean enable) {
-        final MaintenanceRunnableBase runnable = new SingleMaintenanceRunnable(this, settingsProxy, minutes, enable, server);
+        final MaintenanceRunnableBase runnable = new SingleMaintenanceRunnable(this, settingsProxy, minutes * 60, enable, server);
         serverTasks.put(server.getName(), runnable.getTask());
         return runnable;
     }


### PR DESCRIPTION
`SingleMaintenanceRunnable` expects seconds while `starttimer` command expects minutes.