### PR TITLE
fixed spelling issue that caused a message not to work

### DIFF
--- a/maintenance-core/src/main/resources/language-de.yml
+++ b/maintenance-core/src/main/resources/language-de.yml
@@ -37,7 +37,7 @@ whitelistAdded: "&8[&eMaintenance&8] &b%PLAYER% &awurde zur Maintenance Whitelis
 whitelistAlreadyAdded: "&8[&eMaintenance&8] &b%PLAYER% &cist bereits in der Maintenance Whitelist!"
 whitelistRemoved: "&8[&eMaintenance&8] &b%PLAYER% &awurde von der Maintenance Whitelist entfernt!"
 whitelistNotFound: "&8[&eMaintenance&8] &cDieser Spieler ist nicht in der Maintenance Whitelist!"
-whitelistEmtpy: "&8[&eMaintenance&8] &cDie Maintenance Whitelist ist leer! Nutze &e/maintenance add <Spieler/UUID>&c, um jemanden hinzuzufügen!"
+whitelistEmpty: "&8[&eMaintenance&8] &cDie Maintenance Whitelist ist leer! Nutze &e/maintenance add <Spieler/UUID>&c, um jemanden hinzuzufügen!"
 playerNotFound: "&8[&eMaintenance&8] &cBisher hat kein Spieler mit diesem Namen jemals auf diesem Server gespielt."
 playerNotFoundUuid: "&8[&eMaintenance&8] &cEs konnte kein Spieler mit dieser UUID gefunden werden."
 playerNotOnline: "&8[&eMaintenance&8] &cEs ist momentan kein Spieler mit diesem Namen online."


### PR DESCRIPTION
I noticed an issue in the German translation, that caused that the `whitelistEmpty`-message didn't work, so I've just fixed it.