### PR TITLE
Offline player fetching improvements

### DIFF
--- a/bungee/src/main/java/eu/kennytv/maintenance/bungee/MaintenanceBungeePlugin.java
+++ b/bungee/src/main/java/eu/kennytv/maintenance/bungee/MaintenanceBungeePlugin.java
@@ -184,13 +184,7 @@ public final class MaintenanceBungeePlugin extends MaintenanceProxyPlugin {
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ProfileLookup profile = doUUIDLookup(name);
-
-                if (profile == null) {
-                    // Use offline uuid
-                    profile = new ProfileLookup(UUID.fromString("OfflinePlayer:" + name), name);
-                }
-
+                final ProfileLookup profile = doUUIDLookup(name);
                 return new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName());
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/bungee/src/main/java/eu/kennytv/maintenance/bungee/MaintenanceBungeePlugin.java
+++ b/bungee/src/main/java/eu/kennytv/maintenance/bungee/MaintenanceBungeePlugin.java
@@ -61,8 +61,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -176,33 +176,32 @@ public final class MaintenanceBungeePlugin extends MaintenanceProxyPlugin {
     }
 
     @Override
-    public void getOfflinePlayer(final String name, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final String name) {
         final ProxiedPlayer player = getProxy().getPlayer(name);
         if (player != null) {
-            consumer.accept(new BungeeSenderInfo(player));
-            return;
+            return CompletableFuture.completedFuture(new BungeeSenderInfo(player));
         }
 
-        getProxy().getScheduler().runAsync(plugin, () -> {
+        return CompletableFuture.supplyAsync(() -> {
             try {
                 ProfileLookup profile = doUUIDLookup(name);
+
                 if (profile == null) {
                     // Use offline uuid
                     profile = new ProfileLookup(UUID.fromString("OfflinePlayer:" + name), name);
                 }
 
-                consumer.accept(new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName()));
-            } catch (final IOException e) {
-                e.printStackTrace();
-                consumer.accept(null);
+                return new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         });
     }
 
     @Override
-    public void getOfflinePlayer(final UUID uuid, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final UUID uuid) {
         final ProxiedPlayer player = getProxy().getPlayer(uuid);
-        consumer.accept(player != null ? new BungeeSenderInfo(player) : null);
+        return CompletableFuture.completedFuture(player != null ? new BungeeSenderInfo(player) : null);
     }
 
     @Override

--- a/bungee/src/main/java/eu/kennytv/maintenance/bungee/MaintenanceBungeePlugin.java
+++ b/bungee/src/main/java/eu/kennytv/maintenance/bungee/MaintenanceBungeePlugin.java
@@ -185,7 +185,12 @@ public final class MaintenanceBungeePlugin extends MaintenanceProxyPlugin {
 
         getProxy().getScheduler().runAsync(plugin, () -> {
             try {
-                final ProfileLookup profile = doUUIDLookup(name);
+                ProfileLookup profile = doUUIDLookup(name);
+                if (profile == null) {
+                    // Use offline uuid
+                    profile = new ProfileLookup(UUID.fromString("OfflinePlayer:" + name), name);
+                }
+
                 consumer.accept(new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName()));
             } catch (final IOException e) {
                 e.printStackTrace();

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -220,8 +220,8 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
     private UUID fromStringUUIDWithoutDashes(String undashedUUID) {
         return UUID.fromString(
             undashedUUID.substring(0, 8) + "-" + undashedUUID.substring(8, 12) + "-" +
-                undashedUUID.substring(12, 16) + "-" + undashedUUID.substring(16, 20) + "-" +
-                undashedUUID.substring(20, 32)
+            undashedUUID.substring(12, 16) + "-" + undashedUUID.substring(16, 20) + "-" +
+            undashedUUID.substring(20, 32)
         );
     }
 

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -219,7 +219,9 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
 
     private UUID fromStringUUIDWithoutDashes(String undashedUUID) {
         return UUID.fromString(
-            undashedUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5")
+            undashedUUID.substring(0, 8) + "-" + undashedUUID.substring(8, 12) + "-" +
+                undashedUUID.substring(12, 16) + "-" + undashedUUID.substring(16, 20) + "-" +
+                undashedUUID.substring(20, 32)
         );
     }
 

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -211,13 +211,13 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
             final String output = CharStreams.toString(new InputStreamReader(in));
             final JsonObject json = GSON.fromJson(output, JsonObject.class);
 
-            final UUID uuid = toUUIDWithoutDashes(json.getAsJsonPrimitive("id").getAsString());
+            final UUID uuid = fromStringUUIDWithoutDashes(json.getAsJsonPrimitive("id").getAsString());
             final String username = json.getAsJsonPrimitive("name").getAsString();
             return new ProfileLookup(uuid, username);
         }
     }
 
-    private UUID toUUIDWithoutDashes(String undashedUUID) {
+    private UUID fromStringUUIDWithoutDashes(String undashedUUID) {
         return UUID.fromString(
             undashedUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5")
         );

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -201,7 +201,7 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
             profileLookup = doUUIDLookupAshconAPI(name);
         }
 
-        if (profileLookup == null && settingsProxy.isFallbackToOfflineUUID()) {
+        if (settingsProxy.isFallbackToOfflineUUID() && profileLookup == null) {
             // Use offline uuid
             return new ProfileLookup(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)), name);
         }

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -204,7 +204,6 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
             final String output = CharStreams.toString(new InputStreamReader(in));
             final JsonObject json = GSON.fromJson(output, JsonObject.class);
 
-
             final UUID uuid = UUID.fromString(
                 json.getAsJsonPrimitive("id").getAsString()
                     .replaceFirst(

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -211,15 +211,16 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
             final String output = CharStreams.toString(new InputStreamReader(in));
             final JsonObject json = GSON.fromJson(output, JsonObject.class);
 
-            final UUID uuid = UUID.fromString(
-                json.getAsJsonPrimitive("id").getAsString()
-                    .replaceFirst(
-                        "(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5"
-                    )
-            );
+            final UUID uuid = toUUIDWithoutDashes(json.getAsJsonPrimitive("id").getAsString());
             final String username = json.getAsJsonPrimitive("name").getAsString();
             return new ProfileLookup(uuid, username);
         }
+    }
+
+    private UUID toUUIDWithoutDashes(String undashedUUID) {
+        return UUID.fromString(
+            undashedUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5")
+        );
     }
 
     public SettingsProxy getSettingsProxy() {

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/MaintenanceProxyPlugin.java
@@ -190,6 +190,7 @@ public abstract class MaintenanceProxyPlugin extends MaintenancePlugin implement
     }
 
     @Blocking
+    @Nullable
     protected ProfileLookup doUUIDLookup(final String name) throws IOException {
         final URL url = new URL("https://api.mojang.com/users/profiles/minecraft/" + name);
         final HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/SettingsProxy.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/SettingsProxy.java
@@ -39,6 +39,7 @@ public final class SettingsProxy extends Settings {
     private Set<String> maintenanceServers;
     private List<String> fallbackServers;
     private String waitingServer;
+    private boolean fallbackToOfflineUUID;
 
     private Map<String, List<String>> commandsOnMaintenanceEnable;
     private Map<String, List<String>> commandsOnMaintenanceDisable;
@@ -103,6 +104,7 @@ public final class SettingsProxy extends Settings {
         if (waitingServer.isEmpty() || waitingServer.equalsIgnoreCase("none")) {
             waitingServer = null;
         }
+        fallbackToOfflineUUID = config.getBoolean("fallback-to-offline-uuid", false);
 
         commandsOnMaintenanceEnable = new HashMap<>();
         final ConfigSection enableCommandsSection = config.getSection("commands-on-single-maintenance-enable");
@@ -277,6 +279,10 @@ public final class SettingsProxy extends Settings {
     @Nullable
     public String getWaitingServer() {
         return waitingServer;
+    }
+
+    public boolean isFallbackToOfflineUUID() {
+        return fallbackToOfflineUUID;
     }
 
     public List<String> getCommandsOnMaintenanceEnable(final Server server) {

--- a/core/src/main/java/eu/kennytv/maintenance/core/MaintenancePlugin.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/MaintenancePlugin.java
@@ -57,8 +57,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -447,9 +447,9 @@ public abstract class MaintenancePlugin implements Maintenance {
      *
      * @param name name of the player
      */
-    public abstract void getOfflinePlayer(String name, Consumer<@Nullable SenderInfo> consumer);
+    public abstract CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(String name);
 
-    public abstract void getOfflinePlayer(UUID uuid, Consumer<@Nullable SenderInfo> consumer);
+    public abstract CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(UUID uuid);
 
     public abstract File getDataFolder();
 

--- a/core/src/main/java/eu/kennytv/maintenance/core/Settings.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/Settings.java
@@ -41,8 +41,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class Settings implements eu.kennytv.maintenance.api.Settings {
     public static final String NEW_LINE_REPLACEMENT = "<br>";
-    private static final int CONFIG_VERSION = 7;
-    private static final int LANGUAGE_VERSION = 1;
+    private static final int CONFIG_VERSION = 8;
+    private static final int LANGUAGE_VERSION = 2;
     private static final Random RANDOM = new Random();
     protected final MaintenancePlugin plugin;
     private final Map<UUID, String> whitelistedPlayers = new HashMap<>();

--- a/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistAddCommand.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistAddCommand.java
@@ -68,7 +68,7 @@ public final class WhitelistAddCommand extends CommandInfo {
         plugin.getOfflinePlayer(name).whenComplete((selected, ex) -> {
             if (ex != null) {
                 plugin.getLogger().log(Level.SEVERE, "Error while fetching offline player", ex);
-                sender.send(getMessage("offLinePlayerFetchError"));
+                sender.send(getMessage("offlinePlayerFetchError"));
                 return;
             }
 
@@ -85,7 +85,7 @@ public final class WhitelistAddCommand extends CommandInfo {
         plugin.getOfflinePlayer(uuid).whenComplete((selected, ex) -> {
             if (ex != null) {
                 plugin.getLogger().log(Level.SEVERE, "Error while fetching offline player", ex);
-                sender.send(getMessage("offLinePlayerFetchError"));
+                sender.send(getMessage("offlinePlayerFetchError"));
                 return;
             }
 

--- a/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistAddCommand.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistAddCommand.java
@@ -25,6 +25,7 @@ import eu.kennytv.maintenance.core.util.SenderInfo;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.logging.Level;
 
 public final class WhitelistAddCommand extends CommandInfo {
 
@@ -64,7 +65,13 @@ public final class WhitelistAddCommand extends CommandInfo {
     }
 
     private void addPlayerToWhitelist(final SenderInfo sender, final String name) {
-        plugin.getOfflinePlayer(name, selected -> {
+        plugin.getOfflinePlayer(name).whenComplete((selected, ex) -> {
+            if (ex != null) {
+                plugin.getLogger().log(Level.SEVERE, "Error while fetching offline player", ex);
+                sender.send(getMessage("offLinePlayerFetchError"));
+                return;
+            }
+
             if (selected == null) {
                 sender.send(getMessage("playerNotOnline"));
                 return;
@@ -75,7 +82,13 @@ public final class WhitelistAddCommand extends CommandInfo {
     }
 
     private void addPlayerToWhitelist(final SenderInfo sender, final UUID uuid) {
-        plugin.getOfflinePlayer(uuid, selected -> {
+        plugin.getOfflinePlayer(uuid).whenComplete((selected, ex) -> {
+            if (ex != null) {
+                plugin.getLogger().log(Level.SEVERE, "Error while fetching offline player", ex);
+                sender.send(getMessage("offLinePlayerFetchError"));
+                return;
+            }
+
             if (selected == null) {
                 sender.send(getMessage("playerNotFoundUuid"));
                 return;

--- a/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistRemoveCommand.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistRemoveCommand.java
@@ -50,8 +50,9 @@ public final class WhitelistRemoveCommand extends CommandInfo {
         if (args.length != 2) return Collections.emptyList();
 
         final List<String> list = new ArrayList<>();
+        String matchNameLowerCase = args[1].toLowerCase();
         for (final String name : getSettings().getWhitelistedPlayers().values()) {
-            if (name.toLowerCase().startsWith(args[1])) {
+            if (name.toLowerCase().startsWith(matchNameLowerCase)) {
                 list.add(name);
             }
         }

--- a/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistRemoveCommand.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/command/subcommand/WhitelistRemoveCommand.java
@@ -59,7 +59,7 @@ public final class WhitelistRemoveCommand extends CommandInfo {
     }
 
     private void removePlayerFromWhitelist(final SenderInfo sender, final String name) {
-        plugin.getOfflinePlayer(name, selected -> {
+        plugin.getOfflinePlayer(name).whenComplete((selected, ex) -> {
             if (selected == null) {
                 if (getSettings().removeWhitelistedPlayer(name)) {
                     sender.send(getMessage("whitelistRemoved", "%PLAYER%", name));
@@ -74,7 +74,7 @@ public final class WhitelistRemoveCommand extends CommandInfo {
     }
 
     private void removePlayerFromWhitelist(final SenderInfo sender, final UUID uuid) {
-        plugin.getOfflinePlayer(uuid, selected -> {
+        plugin.getOfflinePlayer(uuid).whenComplete((selected, ex) -> {
             if (selected == null) {
                 removePlayerFromWhitelist(sender, uuid, uuid.toString());
             } else {

--- a/core/src/main/java/eu/kennytv/maintenance/core/util/RateLimitedException.java
+++ b/core/src/main/java/eu/kennytv/maintenance/core/util/RateLimitedException.java
@@ -1,0 +1,9 @@
+package eu.kennytv.maintenance.core.util;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when an API rate limit is reached.
+ */
+public class RateLimitedException extends IOException {
+}

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -82,6 +82,9 @@ send-join-notification: false
 # ... I don't know why you would want that, but you can disable it. :p
 kick-online-players: true
 
+# When fetched player does not exist then fallback to offline uuid. Only works on proxies like Velocity or BungeeCord
+fallback-to-offline-uuid: false
+
 # Changes the language of command feedback/messages.
 # If you find missing translations or want to contribute a new language file, you are very welcome to message me on Spigot or my Discord server! :)
 # Currently available are: en (English), de (German), fr (French), pt (Portuguese), es (Spanish), ru (Russian), zh (Chinese), it (Italian),
@@ -123,4 +126,4 @@ timer-broadcast-for-seconds: [1200, 900, 600, 300, 120, 60, 30, 20, 10, 5, 4, 3,
 update-checks: true
 
 # Used for autoupdating the config, do not change this value.
-config-version: 7
+config-version: 8

--- a/core/src/main/resources/language-en.yml
+++ b/core/src/main/resources/language-en.yml
@@ -44,7 +44,7 @@ whitelistEmpty: "<prefix><red>The maintenance whitelist is empty! Use <yellow>/m
 playerNotFound: "<prefix><red>No player with this name has played on this server before."
 playerNotFoundUuid: "<prefix><red>No player with that uuid could be found."
 playerNotOnline: "<prefix><red>There is no player online with that name."
-offLinePlayerFetchError: "<prefix><red>There was an error while fetching offline player. Please try again later."
+offlinePlayerFetchError: "<prefix><red>There was an error while fetching offline player. Please try again later."
 invalidUuid: "<prefix><red>Invalid uuid format!"
 #Messages for the Bungee/Velocity part, you can ignore them if you use the plugin on Spigot/Sponge
 sentToWaitingServer: "<prefix><red>You have been sent to a waiting server!"

--- a/core/src/main/resources/language-en.yml
+++ b/core/src/main/resources/language-en.yml
@@ -101,4 +101,4 @@ helpSingleScheduleTimer: "<gold>/maintenance scheduletimer [server] <timer minut
 helpSingleToggle: "<gold>/maintenance <on/off> [server] <gray>(Enables/disables maintenance mode)"
 helpStatus: "<gold>/maintenance status <gray>(Lists all proxied servers, that are currently under maintenance)"
 #Used for autoupdating the language file, do not change this value.
-language-version: 1
+language-version: 2

--- a/core/src/main/resources/language-en.yml
+++ b/core/src/main/resources/language-en.yml
@@ -44,6 +44,7 @@ whitelistEmpty: "<prefix><red>The maintenance whitelist is empty! Use <yellow>/m
 playerNotFound: "<prefix><red>No player with this name has played on this server before."
 playerNotFoundUuid: "<prefix><red>No player with that uuid could be found."
 playerNotOnline: "<prefix><red>There is no player online with that name."
+offLinePlayerFetchError: "<prefix><red>There was an error while fetching offline player. Please try again later."
 invalidUuid: "<prefix><red>Invalid uuid format!"
 #Messages for the Bungee/Velocity part, you can ignore them if you use the plugin on Spigot/Sponge
 sentToWaitingServer: "<prefix><red>You have been sent to a waiting server!"

--- a/spigot/src/main/java/eu/kennytv/maintenance/spigot/MaintenanceSpigotPlugin.java
+++ b/spigot/src/main/java/eu/kennytv/maintenance/spigot/MaintenanceSpigotPlugin.java
@@ -41,7 +41,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
@@ -140,15 +140,15 @@ public final class MaintenanceSpigotPlugin extends MaintenancePlugin {
     }
 
     @Override
-    public void getOfflinePlayer(final String name, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final String name) {
         final OfflinePlayer player = getServer().getOfflinePlayer(name);
-        consumer.accept(player.getName() != null ? new BukkitOfflinePlayerInfo(player) : null);
+        return CompletableFuture.completedFuture(player.getName() != null ? new BukkitOfflinePlayerInfo(player) : null);
     }
 
     @Override
-    public void getOfflinePlayer(final UUID uuid, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final UUID uuid) {
         final OfflinePlayer player = getServer().getOfflinePlayer(uuid);
-        consumer.accept(player.getName() != null ? new BukkitOfflinePlayerInfo(player) : null);
+        return CompletableFuture.completedFuture(player.getName() != null ? new BukkitOfflinePlayerInfo(player) : null);
     }
 
     @Override

--- a/sponge/src/main/java/eu/kennytv/maintenance/sponge/MaintenanceSpongePlugin.java
+++ b/sponge/src/main/java/eu/kennytv/maintenance/sponge/MaintenanceSpongePlugin.java
@@ -69,8 +69,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -179,36 +179,24 @@ public final class MaintenanceSpongePlugin extends MaintenancePlugin {
     }
 
     @Override
-    public void getOfflinePlayer(final String name, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final String name) {
         final Optional<ServerPlayer> player = game.server().player(name);
         if (player.isPresent()) {
-            consumer.accept(new SpongePlayer(player.get()));
+            return CompletableFuture.completedFuture(new SpongePlayer(player.get()));
         } else {
-            game.server().userManager().load(name).whenComplete((optional, ex) -> {
-                if (ex != null) {
-                    ex.printStackTrace();
-                    consumer.accept(null);
-                } else {
-                    consumer.accept(optional.map(SpongeUser::new).orElse(null));
-                }
-            });
+            return game.server().userManager().load(name)
+                    .thenApply(optional -> optional.map(SpongeUser::new).orElse(null));
         }
     }
 
     @Override
-    public void getOfflinePlayer(final UUID uuid, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final UUID uuid) {
         final Optional<ServerPlayer> player = game.server().player(uuid);
         if (player.isPresent()) {
-            consumer.accept(new SpongePlayer(player.get()));
+            return CompletableFuture.completedFuture(new SpongePlayer(player.get()));
         } else {
-            game.server().userManager().load(uuid).whenComplete((optional, ex) -> {
-                if (ex != null) {
-                    ex.printStackTrace();
-                    consumer.accept(null);
-                } else {
-                    consumer.accept(optional.map(SpongeUser::new).orElse(null));
-                }
-            });
+            return game.server().userManager().load(uuid)
+                    .thenApply(optional -> optional.map(SpongeUser::new).orElse(null));
         }
     }
 

--- a/velocity/src/main/java/eu/kennytv/maintenance/velocity/MaintenanceVelocityPlugin.java
+++ b/velocity/src/main/java/eu/kennytv/maintenance/velocity/MaintenanceVelocityPlugin.java
@@ -234,13 +234,7 @@ public final class MaintenanceVelocityPlugin extends MaintenanceProxyPlugin {
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                ProfileLookup profile = doUUIDLookup(name);
-
-                if (profile == null) {
-                    // Use offline uuid
-                    profile = new ProfileLookup(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)), name);
-                }
-
+                final ProfileLookup profile = doUUIDLookup(name);
                 return new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName());
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/velocity/src/main/java/eu/kennytv/maintenance/velocity/MaintenanceVelocityPlugin.java
+++ b/velocity/src/main/java/eu/kennytv/maintenance/velocity/MaintenanceVelocityPlugin.java
@@ -73,8 +73,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -226,33 +226,32 @@ public final class MaintenanceVelocityPlugin extends MaintenanceProxyPlugin {
     }
 
     @Override
-    public void getOfflinePlayer(final String name, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final String name) {
         final Optional<Player> player = server.getPlayer(name);
         if (player.isPresent()) {
-            consumer.accept(new VelocitySenderInfo(player.get()));
-            return;
+            return CompletableFuture.completedFuture(new VelocitySenderInfo(player.get()));
         }
 
-        async(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             try {
                 ProfileLookup profile = doUUIDLookup(name);
+
                 if (profile == null) {
                     // Use offline uuid
                     profile = new ProfileLookup(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)), name);
                 }
 
-                consumer.accept(new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName()));
-            } catch (final IOException e) {
-                e.printStackTrace();
-                consumer.accept(null);
+                return new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         });
     }
 
     @Override
-    public void getOfflinePlayer(final UUID uuid, final Consumer<@Nullable SenderInfo> consumer) {
+    public CompletableFuture<@Nullable SenderInfo> getOfflinePlayer(final UUID uuid) {
         final Optional<Player> player = server.getPlayer(uuid);
-        consumer.accept(player.map(VelocitySenderInfo::new).orElse(null));
+        return CompletableFuture.completedFuture(player.map(VelocitySenderInfo::new).orElse(null));
     }
 
     @Override

--- a/velocity/src/main/java/eu/kennytv/maintenance/velocity/MaintenanceVelocityPlugin.java
+++ b/velocity/src/main/java/eu/kennytv/maintenance/velocity/MaintenanceVelocityPlugin.java
@@ -67,6 +67,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -234,7 +235,12 @@ public final class MaintenanceVelocityPlugin extends MaintenanceProxyPlugin {
 
         async(() -> {
             try {
-                final ProfileLookup profile = doUUIDLookup(name);
+                ProfileLookup profile = doUUIDLookup(name);
+                if (profile == null) {
+                    // Use offline uuid
+                    profile = new ProfileLookup(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8)), name);
+                }
+
                 consumer.accept(new ProxyOfflineSenderInfo(profile.getUuid(), profile.getName()));
             } catch (final IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
## Changes
- `getOfflinePlayer` now returns `CompletableFuture` instead of passing `Consumer` to it. This allows us for better handling any exceptions in commands.
- Changed api for fetching offline player to use official Minecraft API. Why? Because sometimes the previous api didn't have the latest data. For example I had a bug where my friend created new minecraft account and when I tried to add him to maintenance whitelist, then it would show that player does not exists. I tried multiple times, but without success.
- Added the previous API (Ashcon API) as a fallback when mojang API will rate limit you.
- Added option to proxy config `fallback-to-offline-uuid` to fallback to offline uuid when premium player was not found. Useful on proxy when you have a hybrid setup like:
Premium Player -> Online UUID
Cracked Player -> Offline UUID
- Fixed bug with players tab-completion in command "/maintenance remove"
