### PR TITLE
Fix proxied-maintenance-servers being reset after plugin restart

### DIFF
--- a/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/SettingsProxy.java
+++ b/core-proxy/src/main/java/eu/kennytv/maintenance/core/proxy/SettingsProxy.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 
 public final class SettingsProxy extends Settings {
 
-    private Map<String, String> maintenanceServers = new LinkedHashMap<>();
+    private Map<String, String> maintenanceServers;
     private List<String> fallbackServers;
     private String waitingServer;
     private boolean fallbackToOfflineUUID;


### PR DESCRIPTION
Problem After restarting the proxy plugin, the proxied-maintenance-servers configuration appears to load correctly, but the loaded values are not actually preserved in runtime. As a result, maintenanceServers becomes empty after startup, and the plugin behaves as if no maintenance servers were configured.

This issue is caused by the initialization order in SettingsProxy: the configuration is loaded during the parent constructor, but the maintenanceServers field is then reinitialized by the subclass field initializer, overwriting the loaded values with an empty map.